### PR TITLE
feat: allow to set timezone for datetime parser

### DIFF
--- a/lib/infer_model/parsers/date_time.rb
+++ b/lib/infer_model/parsers/date_time.rb
@@ -22,11 +22,20 @@ module InferModel
 
     param :value
     option :allow_blank, default: -> { true }
+    option :time_zone_offset, default: -> { "+00:00" }
 
     def call
       raise Parsers::Error, "value was blank which is not allowed" if value.nil? && !allow_blank
       return if value.nil? || value.empty?
 
+      datetime_without_zone = parsed_datetime.iso8601[..-7]
+      datetime_with_custom_zone = datetime_without_zone + time_zone_offset
+      DateTime.parse(datetime_with_custom_zone)
+    end
+
+    private
+
+    def parsed_datetime
       ACCEPTABLE_DATETIME_FORMATS.each do |format|
         return DateTime.strptime(value, format)
       rescue Date::Error

--- a/spec/infer_model/parsers/date_time_spec.rb
+++ b/spec/infer_model/parsers/date_time_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe InferModel::Parsers::DateTime do
+  let(:opts) { {} }
+  let(:value) { "05.06.2021 09:18" }
+  subject(:result) { described_class.call(value, **opts) }
+
+  it "assumes UTC time" do
+    expect(result).to eq(DateTime.new(2021, 6, 5, 9, 18))
+  end
+
+  context "with specific time zone" do
+    context "utc" do
+      let(:opts) { { time_zone_offset: "+00:00" } }
+
+      it "respects that assertion" do
+        expect(result).to eq(DateTime.new(2021, 6, 5, 9, 18))
+      end
+    end
+
+    context "Europe/Berlin" do
+      let(:opts) { { time_zone_offset: "+02:00" } }
+
+      it "respects that assertion" do
+        expect(result).to eq(DateTime.new(2021, 6, 5, 7, 18))
+      end
+    end
+  end
+end


### PR DESCRIPTION
that fixes ill formatting when the input is given as local time without specifying the respective time zone
but you know which time zone is meant